### PR TITLE
Remove trading menu, add selling functionality

### DIFF
--- a/ServerEngine/EngineDateien/TControl.cpp
+++ b/ServerEngine/EngineDateien/TControl.cpp
@@ -611,11 +611,6 @@ void TControl::AusgabeSpielRegeln(std::vector<std::string> s, int x, int y) {
     }
     std::cout << _symbolcharsControl[LRC];
 }
-void TControl::AusgabeHandelsMenu(int& option, int x, int y, Farbe f) {//TODO: Handelsmenü implementieren
-    this->SetFarbe(f);
-    this->SetFarbe(Farbe::Schwarz);
-    int maxSizeOption = 0;
-}
 void TControl::AusgabeJaNeinOption(int& option, int x, int y, Farbe f,std::string Ueberschrift) {
     this->SetFarbe(f);
     this->SetFarbe(Farbe::Schwarz);
@@ -795,6 +790,128 @@ void TControl::AusgabeStrasseHandeln(int& option, int& WelcheStrasse,int& Angebo
     SetConsoleCursorPosition(this->hConsole, this->coord);
     this->ShowCursor();
     std::cin >> Angebot;
+    this->HideCursor();
+    this->SetFarbe(Farbe::Zuruecksetzen);
+    std::cin.clear();
+    std::cin.ignore(1000, '\n');
+}
+void TControl::AusgabeVerkaufen(int& option, int& WelcheStrasse, int& Gebaude, int x, int y, Farbe f) {
+    this->SetFarbe(f);
+    this->SetFarbe(Farbe::Schwarz);
+
+    std::string Ueberschrift = "Welche Strasse moechten Sie an die Bank Verkaufen? (Geben sie die Nummer unter der Strasse ein)";
+    int BreiteMenue = Ueberschrift.size() + 10;
+    int linkerRandText = (BreiteMenue - 2) / 2 - Ueberschrift.size() / 2;
+    this->coord.X = x;
+    this->coord.Y = y;
+    int tempy = 0;
+
+    //EINGABE DER STRASSE
+    SetConsoleCursorPosition(this->hConsole, this->coord);
+    std::cout << _symbolcharsControl[ULC];
+    for (size_t i = 1; i < BreiteMenue - 1; i++)
+    {
+        std::cout << _symbolcharsControl[HL];
+    }
+    std::cout << _symbolcharsControl[URC];
+
+    this->coord.Y++;
+    SetConsoleCursorPosition(this->hConsole, this->coord);
+
+    std::cout << _symbolcharsControl[VL] << std::setw(linkerRandText) << " " << std::left << Ueberschrift << std::setw(linkerRandText + 1) << std::right << _symbolcharsControl[VL];
+    this->coord.Y++;
+    SetConsoleCursorPosition(this->hConsole, this->coord);
+
+    std::cout << _symbolcharsControl[VL] << std::setw(BreiteMenue / 2 - 11) << " " << std::left << "Bestaetige mit Enter" << std::setw(BreiteMenue / 2 - 10 + 1) << std::right << _symbolcharsControl[VL];
+    this->coord.Y++;
+    SetConsoleCursorPosition(this->hConsole, this->coord);
+
+    std::cout << _symbolcharsControl[LT];
+    for (size_t i = 1; i < BreiteMenue - 1; i++)
+    {
+        std::cout << _symbolcharsControl[HL];
+    }
+    std::cout << _symbolcharsControl[RT];
+
+    this->coord.Y++;
+    tempy = this->coord.Y;
+    SetConsoleCursorPosition(this->hConsole, this->coord);
+    std::cout << _symbolcharsControl[VL];
+    for (size_t i = 1; i < BreiteMenue - 1; i++)
+    {
+        std::cout << _symbolcharsControl[SP];
+    }
+    std::cout << _symbolcharsControl[VL];
+
+    this->coord.Y++;
+    SetConsoleCursorPosition(this->hConsole, this->coord);
+
+    std::cout << _symbolcharsControl[LLC];
+    for (size_t i = 1; i < BreiteMenue - 1; i++)
+    {
+        std::cout << _symbolcharsControl[HL];
+    }
+    std::cout << _symbolcharsControl[LRC];
+    this->coord.X++;
+    this->coord.Y = tempy;
+    SetConsoleCursorPosition(this->hConsole, this->coord);
+    this->ShowCursor();
+    std::cin >> WelcheStrasse;
+    this->HideCursor();
+    std::cin.clear();
+    std::cin.ignore(1000, '\n');
+
+    //EINGABE DER ANZAHL GEBAUDE
+    Ueberschrift = "Gebe die Anzahl an Gebaeude ein welche du verkaufen willst.";
+    this->coord.X = x;
+    this->coord.Y += 2;
+    SetConsoleCursorPosition(this->hConsole, this->coord);
+    std::cout << _symbolcharsControl[ULC];
+    for (size_t i = 1; i < BreiteMenue - 1; i++)
+    {
+        std::cout << _symbolcharsControl[HL];
+    }
+    std::cout << _symbolcharsControl[URC];
+
+    this->coord.Y++;
+    SetConsoleCursorPosition(this->hConsole, this->coord);
+
+    std::cout << _symbolcharsControl[VL] << std::setw(BreiteMenue / 2 - Ueberschrift.size() / 2) << _symbolcharsControl[SP] << std::left << Ueberschrift << std::setw(BreiteMenue / 2 - Ueberschrift.size() / 2 - 2) << _symbolcharsControl[SP] << std::right << _symbolcharsControl[VL];
+
+    this->coord.Y++;
+    SetConsoleCursorPosition(this->hConsole, this->coord);
+
+    std::cout << _symbolcharsControl[LT];
+    for (size_t i = 1; i < BreiteMenue - 1; i++)
+    {
+        std::cout << _symbolcharsControl[HL];
+    }
+    std::cout << _symbolcharsControl[RT];
+
+    this->coord.Y++;
+    tempy = this->coord.Y;
+    SetConsoleCursorPosition(this->hConsole, this->coord);
+    std::cout << _symbolcharsControl[VL];
+    for (size_t i = 1; i < BreiteMenue - 1; i++)
+    {
+        std::cout << _symbolcharsControl[SP];
+    }
+    std::cout << _symbolcharsControl[VL];
+
+    this->coord.Y++;
+    SetConsoleCursorPosition(this->hConsole, this->coord);
+
+    std::cout << _symbolcharsControl[LLC];
+    for (size_t i = 1; i < BreiteMenue - 1; i++)
+    {
+        std::cout << _symbolcharsControl[HL];
+    }
+    std::cout << _symbolcharsControl[LRC];
+    this->coord.X++;
+    this->coord.Y = tempy;
+    SetConsoleCursorPosition(this->hConsole, this->coord);
+    this->ShowCursor();
+    std::cin >> Gebaude;
     this->HideCursor();
     this->SetFarbe(Farbe::Zuruecksetzen);
     std::cin.clear();
@@ -1631,7 +1748,7 @@ void TControl::UnitTest() {
             TestControl.AusgabeSpielOptionen(option, x / 2 - TestControl.GetLaengstenStringMenueSpielOptionen() /2, y / 2 - TestControl.GetAnzMenuepunkteSpielOptionen() / 2);
             break;
 		case Menues::Handel:
-			TestControl.AusgabeHandelsMenu(option, x / 2 - TestControl.GetLaengstenStringMenueSpielerOptionen() / 2, y / 2 - TestControl.GetAnzMenuepunkteSpielerOptionen() / 2, Farbe::BG_Gelb); //die Farbe dem zugehörigen Spieler anpassen
+			//TestControl.AusgabeHandelsMenu(option, x / 2 - TestControl.GetLaengstenStringMenueSpielerOptionen() / 2, y / 2 - TestControl.GetAnzMenuepunkteSpielerOptionen() / 2, Farbe::BG_Gelb); //die Farbe dem zugehörigen Spieler anpassen
         default:
             break;
         }

--- a/ServerEngine/EngineDateien/TControl.h
+++ b/ServerEngine/EngineDateien/TControl.h
@@ -110,7 +110,7 @@ private:
 
     //Menüs
     std::vector<std::string> MenueStartOptionen = { "Spiel starten","Highscore","Optionen","Beenden","##################################################","Startmenue"};
-    std::vector<std::string> MenueSpielerOptionen = { "Wuerfeln","Kaufen","Bauen","Handeln","Runde Beenden","##################################################","Spielermenue"};
+    std::vector<std::string> MenueSpielerOptionen = { "Wuerfeln","Kaufen","Bauen","Handeln","Verkaufen","Runde Beenden","##################################################","Spielermenue"};
     std::vector<std::string> MenueSpielOptionen = { "Fortfahren","Spiel Speichern","Spiel Laden","Spielregeln","Beenden","Highscore","Zurueck","##################################################","Spielmenue"};
     std::vector<std::string> SpielerInformationen = { "Budget","Anzahl gekaufter Objekte","Anzahl gebauter Objekte","#############################################","Was willst du machen?" };
 
@@ -138,13 +138,13 @@ public:
     void AusgabeStartMenu(int& option, int x, int y);
 	
     void AusgabeJaNeinOption(int& option, int x, int y, Farbe f, std::string Ueberschrift);
-    void AusgabeStrasseHandeln(int& option,int& WelcheStrasse, int& Angebot, int x, int y, Farbe f);
+    void AusgabeStrasseHandeln(int& option, int& WelcheStrasse, int& Angebot, int x, int y, Farbe f);
+    void AusgabeVerkaufen(int& option,int& WelcheStrasse, int& Gebaude, int x, int y, Farbe f);
     void AusgabeGebaeudeBauen(int& option, int& WelcheStrasse, int x, int y, Farbe f);
 	void AusgabeAuswahlSpieler(int& option, int x, int y, Farbe f, int& AnzahlSpieler, int& AnzahlCpuGegner, std::vector<std::string>& SpielerNamen);
     void AusgabeSpielOptionen(int& option, int x, int y);
     void AusgabeSpielerOptionen(int& option, int x, int y, Farbe f);
     void AusgabeSpielRegeln(std::vector<std::string> s, int x, int y);
-	void AusgabeHandelsMenu(int& option, int x, int y, Farbe f);
     void AusgabeStartBildschirm(bool flip, int x, int y);
     void AusgabeFeld(std::string Feld, int x, int y);
     void AusgabeSpielerInformationen(   std::string Namen[4],int Budget[4],

--- a/ServerEngine/TServerEngine.cpp
+++ b/ServerEngine/TServerEngine.cpp
@@ -18,6 +18,7 @@ void TServer::UnitTest() {
         Kaufen,
         Bauen,
         Handeln, 
+        Verkaufen,
         RundeBeenden,
         Fortfahren,
         SpielSpeichern,
@@ -324,6 +325,13 @@ void TServer::UnitTest() {
                         //player[MomentanerSpieler].handel(board.(MomentanerSpieler, player[MomentanerSpieler].getBudget()));
 					    //TODO: ConfigEngineLogging.playerTradesObject("Objekt wurde gehandelt");
                     }
+                    if (option + MenueOptionen::Wuerfeln == MenueOptionen::Verkaufen) {
+                        int Strasse = -1,Gebaude = -1;
+                        ControlEngine.AusgabeVerkaufen(option, Strasse,Gebaude, x / 2 - 215, y / 2 - 20, Farbe::BG_Rot);
+
+                        //Logik wegen dem Verkaufen - Abfrage ob Gebaude und Strasse in Besitz zum Verkaufen 
+                        system("cls");
+                    }
                     if (option + MenueOptionen::Wuerfeln == MenueOptionen::RundeBeenden)
                     {
                         if (HatGewuerfelt)
@@ -418,8 +426,8 @@ void TServer::UnitTest() {
                     if ((option + MenueOptionen::Fortfahren) == MenueOptionen::SpielRegeln) { 
                         ControlEngine.AusgabeSpielRegeln(Spielregeln, x / 2 - this->GetLongestStringVector(Spielregeln)/ 2 - 8, y / 2 + ControlEngine.GetAnzMenuepunkteSpielOptionen() + 2); 
                     }
-                    if ((option + MenueOptionen::Fortfahren) == MenueOptionen::Beenden + 10) { Spiellaueft = FALSE; }
-                    if ((option + MenueOptionen::Fortfahren) == MenueOptionen::Highscore + 13) { 
+                    if ((option + MenueOptionen::Fortfahren) == MenueOptionen::Beenden + 11) { Spiellaueft = FALSE; }
+                    if ((option + MenueOptionen::Fortfahren) == MenueOptionen::Highscore + 14) { 
                         std::vector<HighscoreEntry> player;
                         load_highscores("highscores.txt", player);
                         std::vector<std::string> playerNames;


### PR DESCRIPTION
Remove trading menu, add selling functionality

- Removed `AusgabeHandelsMenu` function and its declaration.
- Added `AusgabeVerkaufen` function for selling streets and buildings.
- Updated `MenueSpielerOptionen` to include "Verkaufen" option.
- Modified `AusgabeStrasseHandeln` signature for clarity.
- Commented out `AusgabeHandelsMenu` in unit tests.
- Updated unit tests in `TServerEngine.cpp` to handle selling logic.
- Adjusted menu option offsets for game ending and high score access.